### PR TITLE
use index to find all annotation with step definition

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -49,6 +49,7 @@
 	  <configurationType implementation="cd.connect.idea.plugins.cucumber.dart.steps.run.CucumberDartRunConfigurationType"/>
     <implicitUsageProvider implementation="cd.connect.idea.plugins.cucumber.dart.steps.reference.CucumberJavaImplicitUsageProvider"/>
     <multiHostInjector implementation="cd.connect.idea.plugins.cucumber.dart.CucumberDartInjector"/>
+    <fileBasedIndex implementation="cd.connect.idea.plugins.cucumber.dart.DartCucumberIndex"/>
   </extensions>
 
   <extensions defaultExtensionNs="org.jetbrains.plugins.cucumber.steps">

--- a/src/cd/connect/idea/plugins/cucumber/dart/CucumberDartNIExtension.java
+++ b/src/cd/connect/idea/plugins/cucumber/dart/CucumberDartNIExtension.java
@@ -1,104 +1,32 @@
 package cd.connect.idea.plugins.cucumber.dart;
 
+import cd.connect.idea.plugins.cucumber.dart.steps.DartAnnotatedStepDefinition;
 import cd.connect.idea.plugins.cucumber.dart.steps.DartStepDefinitionCreator;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
-import com.intellij.openapi.module.ModuleType;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.ModuleRootManager;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.util.PsiTreeUtil;
-import com.intellij.util.containers.ContainerUtil;
+import com.intellij.util.indexing.FileBasedIndex;
 import com.jetbrains.lang.dart.DartFileType;
-import com.jetbrains.lang.dart.projectWizard.DartModuleBuilder;
-import com.jetbrains.lang.dart.psi.DartClassDefinition;
-import com.jetbrains.lang.dart.psi.DartClassMembers;
 import com.jetbrains.lang.dart.psi.DartFile;
+import com.jetbrains.lang.dart.psi.DartMethodDeclaration;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.plugins.cucumber.BDDFrameworkType;
 import org.jetbrains.plugins.cucumber.StepDefinitionCreator;
-import cd.connect.idea.plugins.cucumber.dart.steps.DartAnnotatedStepDefinition;
 import org.jetbrains.plugins.cucumber.psi.GherkinFile;
+import org.jetbrains.plugins.cucumber.steps.AbstractCucumberExtension;
 import org.jetbrains.plugins.cucumber.steps.AbstractStepDefinition;
-import org.jetbrains.plugins.cucumber.steps.NotIndexedCucumberExtension;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
-public class CucumberDartNIExtension extends NotIndexedCucumberExtension {
-  @Override
-  protected void loadStepDefinitionRootsFromLibraries(Module module, List<PsiDirectory> roots, Set<String> directories) {
-  }
-
-  @Override
-  protected Collection<AbstractStepDefinition> getStepDefinitions(@NotNull PsiFile psiFile) {
-    final List<AbstractStepDefinition> newDefs = new ArrayList<>();
-    if (psiFile instanceof DartFile) {
-      final DartClassDefinition clazz = PsiTreeUtil.getChildOfType(psiFile, DartClassDefinition.class);
-
-      if (clazz != null && clazz.getClassBody() != null && clazz.getClassBody().getClassMembers() != null) {
-        DartClassMembers cMembers = clazz.getClassBody().getClassMembers();
-        cMembers.getMethodDeclarationList().forEach(member -> {
-          String annotation = CucumberDartUtil.findDartCucumberAnnotation(member);
-
-          if (annotation != null) {
-            newDefs.add(new DartAnnotatedStepDefinition(member, annotation));
-          }
-        });
-      }
-    }
-    return newDefs;
-  }
-
-  @Override
-  protected void collectAllStepDefsProviders(@NotNull List<VirtualFile> providers, @NotNull Project project) {
-    final Module[] modules = ModuleManager.getInstance(project).getModules();
-    final DartModuleBuilder dmb = new DartModuleBuilder();
-    ModuleType moduleType = dmb.getModuleType();
-    for (Module module : modules) {
-      if (ModuleType.get(module).equals(moduleType)) {
-        final VirtualFile[] roots = ModuleRootManager.getInstance(module).getContentRoots();
-        ContainerUtil.addAll(providers, roots);
-      }
-    }
-
-  }
-
-  @Override
-  public void findRelatedStepDefsRoots(@NotNull final Module module, @NotNull final PsiFile featureFile,
-                                       List<PsiDirectory> newStepDefinitionsRoots, Set<String> processedStepDirectories) {
-    // ToDo: check if inside test folder
-    PsiDirectory currDir = featureFile.getContainingDirectory();
-    PsiDirectory featureFileDirectory = currDir;
-
-    while (currDir != null && currDir.isDirectory() && (!currDir.getName().equals("test_driver") || currDir.getName().equals("test"))) {
-      if ("steps".equals(currDir.getName())) {
-        if (!processedStepDirectories.contains(currDir.getVirtualFile().getPath())) {
-          newStepDefinitionsRoots.add(currDir);
-        }
-      }
-
-      Arrays.stream(currDir.getSubdirectories()).filter(d -> "steps".equals(d.getName())).findFirst().ifPresent(d -> {
-        if (!processedStepDirectories.contains(d.getVirtualFile().getPath())) {
-          newStepDefinitionsRoots.add(d);
-        }
-      });
-
-      currDir = currDir.getParentDirectory();
-    }
-
-    if (currDir != null && !processedStepDirectories.contains(currDir.getVirtualFile().getPath())) {
-      newStepDefinitionsRoots.add(currDir);
-    }
-  }
-
+public class CucumberDartNIExtension extends AbstractCucumberExtension {
   @Override
   public boolean isStepLikeFile(@NotNull PsiElement child, @NotNull PsiElement parent) {
     return child instanceof DartFile && ((DartFile)child).getName().endsWith(".dart");
@@ -119,5 +47,58 @@ public class CucumberDartNIExtension extends NotIndexedCucumberExtension {
   @Override
   public StepDefinitionCreator getStepDefinitionCreator() {
     return new DartStepDefinitionCreator();
+  }
+
+  @Override
+  public List<AbstractStepDefinition> loadStepsFor(@Nullable PsiFile featureFile, @NotNull Module module) {
+    final List<AbstractStepDefinition> result = new ArrayList<>();
+    final FileBasedIndex fileBasedIndex = FileBasedIndex.getInstance();
+
+    Project project = module.getProject();
+    fileBasedIndex.processValues(DartCucumberIndex.INDEX_ID, true, null,
+            (file, value) -> {
+              ProgressManager.checkCanceled();
+
+              PsiFile psiFile = PsiManager.getInstance(project).findFile(file);
+              if (psiFile == null) {
+                return true;
+              }
+
+              for (Integer offset : value) {
+                PsiElement element = psiFile.findElementAt(offset + 1);
+                DartMethodDeclaration member = PsiTreeUtil.getParentOfType(element, DartMethodDeclaration.class);
+                if (member == null) {
+                  continue;
+                }
+                String annotation = CucumberDartUtil.findDartCucumberAnnotation(member);
+                if (annotation != null) {
+                  result.add(new DartAnnotatedStepDefinition(member, annotation));
+                }
+              }
+              return true;
+            }, GlobalSearchScope.projectScope(project));
+    return result;
+  }
+
+  @Override
+  public Collection<? extends PsiFile> getStepDefinitionContainers(@NotNull GherkinFile featureFile) {
+    final Module module = ModuleUtilCore.findModuleForPsiElement(featureFile);
+    if (module == null) {
+      return Collections.emptySet();
+    }
+    List<AbstractStepDefinition> stepDefs = loadStepsFor(featureFile, module);
+
+    Set<PsiFile> result = new HashSet<>();
+    for (AbstractStepDefinition stepDef : stepDefs) {
+      PsiElement stepDefElement = stepDef.getElement();
+      if (stepDefElement != null) {
+        final PsiFile psiFile = stepDefElement.getContainingFile();
+        PsiDirectory psiDirectory = psiFile.getParent();
+        if (psiDirectory != null && isWritableStepLikeFile(psiFile, psiDirectory)) {
+          result.add(psiFile);
+        }
+      }
+    }
+    return result;
   }
 }

--- a/src/cd/connect/idea/plugins/cucumber/dart/CucumberStepIndex.java
+++ b/src/cd/connect/idea/plugins/cucumber/dart/CucumberStepIndex.java
@@ -1,0 +1,175 @@
+// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package cd.connect.idea.plugins.cucumber.dart;
+
+import com.intellij.lang.LighterAST;
+import com.intellij.lang.LighterASTNode;
+import com.intellij.util.indexing.DataIndexer;
+import com.intellij.util.indexing.FileBasedIndexExtension;
+import com.intellij.util.indexing.FileContent;
+import com.intellij.util.indexing.PsiDependentFileContent;
+import com.intellij.util.io.BooleanDataDescriptor;
+import com.intellij.util.io.DataExternalizer;
+import com.intellij.util.io.KeyDescriptor;
+import com.intellij.util.text.StringSearcher;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.*;
+
+public abstract class CucumberStepIndex extends FileBasedIndexExtension<Boolean, List<Integer>> {
+    private static final List<String> STEP_KEYWORDS = Arrays.asList("Әмма", "Нәтиҗәдә", "Вә", "Әйтик", "Һәм", "Ләкин", "Әгәр",  "Und",
+            "Angenommen", "Gegeben seien",  "Dann", "Aber", "Wenn", "Gegeben sei",
+            "यदि", "तदा", "अगर", "और", "कदा", "परन्तु", "चूंकि", "जब", "किन्तु", "तथा", "पर",
+            "तब", "Dados", "Entao", "Dada", "Então", "Mas", "Dadas", "Dado",
+            "Quando", "E", "Bet", "Ir", "Tada",  "Kai", "Duota", "awer", "a", "an",
+            "wann", "mä", "ugeholl", "dann", "I", "Kada", "Kad", "Zadan", "Ali",
+            "Onda", "Zadano",  "Zadani", "Bet", "Kad", "Tad", "Ja", "Un",  "E",
+            "Sipoze ke", "Sipoze", "Epi",  "Men", "Le sa a", "Le", "Ak", "Lè",
+            "Sipoze Ke", "Lè sa a", "Ha", "Adott", "De", "Amikor", "És", "Majd",
+            "Akkor", "Amennyiben",  "并且", "而且", "假如", "同时", "当", "假设", "那么",
+            "假定",  "但是", "Нехай", "Якщо", "І", "Припустимо, що", "Дано",
+            "Припустимо", "Коли", "Та", "Але", "То", "Тоді",  "А також",
+            "It's just unbelievable", "Yeah nah",  "Too right",
+            "But at the end of the day I reckon", "Y'know", "Maka",  "Tapi",
+            "Ketika", "Dengan", "Dan", "اگر", "تب", "اور", "جب", "بالفرض",
+            "فرض کیا", "پھر", "لیکن", "Maar",  "En", "Dan", "Wanneer", "Gegewe",
+            "Бирок", "Аммо", "Унда",  "Ва", "Лекин", "Агар", "Δεδομένου", "Τότε",
+            "Και", "Αλλά", "Όταν", "Aye", "Let go and haul", "Gangway!",
+            "Avast!", "Blimey!", "When", "Then", "Given", "But",  "And", "Kaj",
+            "Do", "Se", "Sed", "Donitaĵo", "Ef", "Þegar", "Þá",  "En", "Og",
+            "Quando", "E", "Allora", "Dato", "Dati", "Date", "Data", "Ma",
+            "Cuando", "Dada", "Pero", "Entonces", "Dados", "Y", "Dadas", "Dado",
+            "Kui",  "Ja", "Eeldades", "Kuid", "Siis", "اذاً", "لكن", "و",
+            "متى", "بفرض", "ثم", "عندما", "Thì", "Khi", "Biết", "Và", "Cho", "Nhưng",
+            "もし", "かつ", "但し", "ただし", "しかし", "ならば",  "前提", "A",
+            "Anrhegedig a", "Pryd",  "Yna", "Ond", "هنگامی",  "با فرض", "آنگاه",
+            "اما", "و", "Dat fiind", "Dati fiind", "Atunci", "Dați fiind", "Dar",
+            "Si", "Când", "Daţi fiind", "Și",  "Cand", "Şi", "Date fiind", "Als",
+            "Maar", "Gegeven", "En", "Wanneer", "Stel", "Dan", "Gitt", "Så", "Når",
+            "Men", "Og", "Mutta", "Ja",  "Oletetaan", "Kun", "Niin", "Пусть",
+            "Допустим", "К тому же", "То", "Дано", "Когда", "Но", "Тогда", "Если",
+            "И",  "А", "Также", "Дадено", "И",  "То", "Когато", "Но", "Maka",
+            "Apabila", "Tapi", "Kemudian", "Dan", "Tetapi", "Diberi", "Bagi",
+            "Etant donnés", "Alors", "Étant données", "Etant donné", "Étant donnée",
+            "Lorsqu'", "Etant donnée", "Et", "Étant donné", "Quand", "Lorsque",
+            "Mais", "Soit", "Etant données",  "Étant donnés", "Njuk", "Tapi",
+            "Menawa", "Nalika", "Ananging", "Lan",  "Nanging", "Manawa", "Nalikaning",
+            "Banjur", "Givun", "Youse know when youse got", "Youse know like when",
+            "An", "Den youse gotta", "Buh", "Dun",  "Wun", "WEN", "I CAN HAZ", "BUT",
+            "AN", "DEN", "Potom", "Za predpokladu", "Tak", "Pokiaľ", "A zároveň", "A",
+            "Ak", "A taktiež", "Ale", "Keď", "A tiež", "Privzeto", "Ampak", "Takrat",
+            "Ko", "Nato", "Zaradi", "Ce", "Potem", "Če", "Ter", "Kadar", "Toda",
+            "Dano", "Podano", "Vendar", "In", "I", "Atesa", "Donada", "Aleshores",
+            "Cal", "Però", "Donat", "Quan",  "Atès", "ನೀಡಿದ", "ಮತ್ತು",  "ಆದರೆ", "ನಂತರ",
+            "ಸ್ಥಿತಿಯನ್ನು", "Så", "När", "Och", "Men", "Givet", "그러면",  "만약", "먼저",
+            "조건", "단", "만일", "하지만", "그리고", "Mais",  "E", "Dada", "Pero", "Dados",
+            "Logo", "Cando", "Dadas", "Dado", "Entón", "那麼", "假如", "而且", "同時",
+            "假設", "當", "假定",  "但是", "並且", "And y'all", "But y'all", "When y'all",
+            "Then y'all", "Given y'all", "Zadate", "I", "Kad", "Zatati", "Ali",
+            "Kada", "Onda",  "Zadato", "Pak", "A", "Ale", "A také", "Když",
+            "Za předpokladu", "Pokud", "ਅਤੇ", "ਜਿਵੇਂ ਕਿ", "ਪਰ", "ਜੇਕਰ", "ਜਦੋਂ", "ਤਦ",
+            "Задато", "Кад", "Задати", "Када", "Задате", "Али", "Онда", "И",
+            "ghu' noblu'", "DaH ghu' bejlu'", "latlh", "qaSDI'", "'ach", "'ej", "'a",
+            "vaj", "กำหนดให้", "แต่", "และ",  "เมื่อ", "ดังนั้น", "మరియు", "అప్పుడు",
+            "ఈ పరిస్థితిలో", "చెప్పబడినది", "కాని", "I",  "Gdy", "Kiedy", "Wtedy", "Ale",
+            "Jeżeli", "Jeśli", "Mając", "Zakładając", "Oraz", "Og", "Så", "Når",
+            "Men", "Givet", "כאשר", "וגם", "אז",  "בהינתן", "אבל", "אזי",
+            "Ond", "Ðurh", "Ða", "Ða ðe", "Ac", "Thurh", "Þa", "7", "Þa þe", "Tha",
+            "Þurh",  "Tha the", "Ama", "Fakat", "O zaman",  "Ve", "Eğer ki",
+            "Diyelim ki");
+
+    @NotNull
+    @Override
+    public DataIndexer<Boolean, List<Integer>, FileContent> getIndexer() {
+        return inputData -> {
+            CharSequence text = inputData.getContentAsText();
+            boolean found = false;
+            for (String pkg : getPackagesToScan()) {
+                StringSearcher searcher = new StringSearcher(pkg, true, true);
+                if (isCucumberStepDefinitionFile(searcher, text)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                return Collections.emptyMap();
+            }
+
+            LighterAST lighterAst = ((PsiDependentFileContent)inputData).getLighterAST();
+            List<Integer> result = getAllStepDefinitionCalls(lighterAst, text);
+            Map<Boolean, List<Integer>> resultMap = new HashMap<>();
+            resultMap.put(true, result);
+            return resultMap;
+        };
+    }
+
+    @NotNull
+    @Override
+    public KeyDescriptor<Boolean> getKeyDescriptor() {
+        return BooleanDataDescriptor.INSTANCE;
+    }
+
+    @NotNull
+    @Override
+    public DataExternalizer<List<Integer>> getValueExternalizer() {
+        return DATA_EXTERNALIZER;
+    }
+
+    @Override
+    public boolean hasSnapshotMapping() {
+        return true;
+    }
+
+    @Override
+    public boolean dependsOnFileContent() {
+        return true;
+    }
+
+    protected abstract String[] getPackagesToScan();
+
+    private static boolean isCucumberStepDefinitionFile(@NotNull StringSearcher searcher, @NotNull CharSequence text) {
+        return searcher.scan(text) > 0;
+    }
+
+    protected static boolean isStepDefinitionCall(@NotNull LighterASTNode methodName, @NotNull CharSequence text) {
+        return STEP_KEYWORDS.contains(text.subSequence(methodName.getStartOffset(), methodName.getEndOffset()).toString());
+    }
+
+    protected static boolean isStringLiteral(@NotNull LighterASTNode element, @NotNull CharSequence text) {
+        return text.charAt(element.getStartOffset()) == '"';
+    }
+
+    protected static boolean isNumber(@NotNull LighterASTNode element, @NotNull CharSequence text) {
+        for (int i = element.getStartOffset(); i < element.getEndOffset(); i++) {
+            if (!Character.isDigit(text.charAt(i))) {
+                return false;
+            }
+        }
+
+        return element.getEndOffset() - element.getStartOffset() > 0;
+    }
+
+    protected abstract List<Integer> getAllStepDefinitionCalls(@NotNull LighterAST lighterAst, @NotNull CharSequence text);
+
+    private static final DataExternalizer<List<Integer>> DATA_EXTERNALIZER = new DataExternalizer<List<Integer>>() {
+        @Override
+        public void save(@NotNull DataOutput out, List<Integer> value) throws IOException {
+            out.writeInt(value.size());
+            for (Integer number : value) {
+                out.writeInt(number);
+            }
+        }
+
+        @Override
+        public List<Integer> read(@NotNull DataInput in) throws IOException {
+            int size = in.readInt();
+            List<Integer> result = new ArrayList<>();
+            for (int i = 0; i < size; i++) {
+                result.add(in.readInt());
+            }
+            return result;
+        }
+    };
+}

--- a/src/cd/connect/idea/plugins/cucumber/dart/DartCucumberIndex.java
+++ b/src/cd/connect/idea/plugins/cucumber/dart/DartCucumberIndex.java
@@ -1,0 +1,76 @@
+package cd.connect.idea.plugins.cucumber.dart;
+
+import com.intellij.lang.LighterAST;
+import com.intellij.lang.LighterASTNode;
+import com.intellij.psi.impl.source.tree.LightTreeUtil;
+import com.intellij.psi.impl.source.tree.RecursiveLighterASTNodeWalkingVisitor;
+import com.intellij.util.indexing.DefaultFileTypeSpecificInputFilter;
+import com.intellij.util.indexing.FileBasedIndex;
+import com.intellij.util.indexing.ID;
+import com.jetbrains.lang.dart.DartFileType;
+import com.jetbrains.lang.dart.DartTokenTypes;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DartCucumberIndex extends CucumberStepIndex {
+    public static final ID<Boolean, List<Integer>> INDEX_ID = ID.create("groovy.cucumber.step");
+
+    @Override
+    protected String[] getPackagesToScan() {
+        return new String[] {"package:ogurets/ogurets.dart"};
+    }
+
+    @Override
+    protected List<Integer> getAllStepDefinitionCalls(@NotNull LighterAST lighterAst, @NotNull CharSequence text) {
+        List<Integer> result = new ArrayList<>();
+
+        RecursiveLighterASTNodeWalkingVisitor visitor = new RecursiveLighterASTNodeWalkingVisitor(lighterAst) {
+            @Override
+            public void visitNode(@NotNull LighterASTNode element) {
+                if (element.getTokenType() == DartTokenTypes.METADATA) {
+                    List<LighterASTNode> methodNameAndArgumentList = lighterAst.getChildren(element);
+                    if (methodNameAndArgumentList.size() < 3) {
+                        super.visitNode(element);
+                        return;
+                    }
+                    LighterASTNode methodNameNode = methodNameAndArgumentList.get(1);
+                    if (methodNameNode != null && isStepDefinitionCall(methodNameNode, text)) {
+                        LighterASTNode expressionList = methodNameAndArgumentList.get(2);
+                        if (expressionList.getTokenType() == DartTokenTypes.ARGUMENTS) {
+                            LighterASTNode argumentList = LightTreeUtil.firstChildOfType(lighterAst, expressionList, DartTokenTypes.ARGUMENT_LIST);
+                            if (argumentList != null) {
+                                LighterASTNode expressionParameter = LightTreeUtil.firstChildOfType(lighterAst, argumentList, DartTokenTypes.STRING_LITERAL_EXPRESSION);
+                                if (expressionParameter != null) {
+                                    result.add(expressionParameter.getStartOffset());
+                                }
+                            }
+                        }
+                    }
+                }
+                super.visitNode(element);
+            }
+        };
+        visitor.visitNode(lighterAst.getRoot());
+
+        return result;
+    }
+
+    @NotNull
+    @Override
+    public ID<Boolean, List<Integer>> getName() {
+        return INDEX_ID;
+    }
+
+    @Override
+    public int getVersion() {
+        return 2;
+    }
+
+    @NotNull
+    @Override
+    public FileBasedIndex.InputFilter getInputFilter() {
+        return new DefaultFileTypeSpecificInputFilter(DartFileType.INSTANCE);
+    }
+}


### PR DESCRIPTION
We are going to remove NotIndexedCucumberExtension in 2020.1 release. This PR will help to make the plugin compatible with the upcoming release of IDEA. Also using index instead of scanning each .dart file should improve performance of the plugin.

Unfortunately I didn't find any tests in the project, so I can't be sure if I broke anything or not. At least samples from official page of ogurets package work fine.