### PR TITLE
Import stepdefs from packages in generated `ogurets_run.dart`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 # dart-ogurets-intellij-plugin Changelog
 
 ## [Unreleased]
+### Added
+- the generated `ogurets_run.dart` file will include required step defs from imported packages, enabling reuse of step definitions across multiple packages (#16)
+
+## [2.0.0]
 ### Changed
 - converted project to build using gradle 
 - upgraded minimal compatibility from 2021.3 to 2022.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = ogurets--cucumber-for-dart--by-blue-biscuit-design
 pluginName = ogurets--cucumber-for-dart--by-blue-biscuit-design
 pluginRepositoryUrl = https://github.com/dart-ogurets/OguretsIntellij
 # SemVer format -> https://semver.org
-pluginVersion = 2.0.0
+pluginVersion = 2.0.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223

--- a/src/main/java/dev/bluebiscuitdesign/cucumber/dart/CucumberDartNIExtension.java
+++ b/src/main/java/dev/bluebiscuitdesign/cucumber/dart/CucumberDartNIExtension.java
@@ -1,20 +1,9 @@
 package dev.bluebiscuitdesign.cucumber.dart;
 
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleUtilCore;
-import com.intellij.openapi.progress.ProgressManager;
-import com.intellij.openapi.project.Project;
-import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
-import com.intellij.psi.PsiManager;
-import com.intellij.psi.search.GlobalSearchScope;
-import com.intellij.psi.util.PsiTreeUtil;
-import com.intellij.util.indexing.FileBasedIndex;
 import com.jetbrains.lang.dart.DartFileType;
-import com.jetbrains.lang.dart.psi.DartFile;
-import com.jetbrains.lang.dart.psi.DartMethodDeclaration;
-import dev.bluebiscuitdesign.cucumber.dart.steps.DartAnnotatedStepDefinition;
 import dev.bluebiscuitdesign.cucumber.dart.steps.DartStepDefinitionCreator;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -24,17 +13,18 @@ import org.jetbrains.plugins.cucumber.psi.GherkinFile;
 import org.jetbrains.plugins.cucumber.steps.AbstractCucumberExtension;
 import org.jetbrains.plugins.cucumber.steps.AbstractStepDefinition;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
 
 public class CucumberDartNIExtension extends AbstractCucumberExtension {
     @Override
     public boolean isStepLikeFile(@NotNull PsiElement child, @NotNull PsiElement parent) {
-        return child instanceof DartFile && ((DartFile) child).getName().endsWith(".dart");
+        return CucumberDartUtil.isStepLikeFile(child, parent);
     }
 
     @Override
     public boolean isWritableStepLikeFile(@NotNull PsiElement child, @NotNull PsiElement parent) {
-        return isStepLikeFile(child, parent);
+        return CucumberDartUtil.isWritableStepLikeFile(child, parent);
     }
 
     @NotNull
@@ -51,54 +41,11 @@ public class CucumberDartNIExtension extends AbstractCucumberExtension {
 
     @Override
     public List<AbstractStepDefinition> loadStepsFor(@Nullable PsiFile featureFile, @NotNull Module module) {
-        final List<AbstractStepDefinition> result = new ArrayList<>();
-        final FileBasedIndex fileBasedIndex = FileBasedIndex.getInstance();
-
-        Project project = module.getProject();
-        fileBasedIndex.processValues(DartCucumberIndex.INDEX_ID, true, null,
-                (file, value) -> {
-                    ProgressManager.checkCanceled();
-
-                    PsiFile psiFile = PsiManager.getInstance(project).findFile(file);
-                    if (psiFile == null) {
-                        return true;
-                    }
-
-                    for (Integer offset : value) {
-                        PsiElement element = psiFile.findElementAt(offset + 1);
-                        DartMethodDeclaration member = PsiTreeUtil.getParentOfType(element, DartMethodDeclaration.class);
-                        if (member == null) {
-                            continue;
-                        }
-                        String annotation = CucumberDartUtil.findDartCucumberAnnotation(member);
-                        if (annotation != null) {
-                            result.add(new DartAnnotatedStepDefinition(member, annotation));
-                        }
-                    }
-                    return true;
-                }, GlobalSearchScope.projectScope(project));
-        return result;
+        return CucumberDartUtil.loadStepsFor(featureFile, module);
     }
 
     @Override
     public Collection<? extends PsiFile> getStepDefinitionContainers(@NotNull GherkinFile featureFile) {
-        final Module module = ModuleUtilCore.findModuleForPsiElement(featureFile);
-        if (module == null) {
-            return Collections.emptySet();
-        }
-        List<AbstractStepDefinition> stepDefs = loadStepsFor(featureFile, module);
-
-        Set<PsiFile> result = new HashSet<>();
-        for (AbstractStepDefinition stepDef : stepDefs) {
-            PsiElement stepDefElement = stepDef.getElement();
-            if (stepDefElement != null) {
-                final PsiFile psiFile = stepDefElement.getContainingFile();
-                PsiDirectory psiDirectory = psiFile.getParent();
-                if (psiDirectory != null && isWritableStepLikeFile(psiFile, psiDirectory)) {
-                    result.add(psiFile);
-                }
-            }
-        }
-        return result;
+        return CucumberDartUtil.getStepDefinitionContainers(featureFile);
     }
 }

--- a/src/main/java/dev/bluebiscuitdesign/cucumber/dart/steps/run/CucumberDartRunConfigurationProducer.java
+++ b/src/main/java/dev/bluebiscuitdesign/cucumber/dart/steps/run/CucumberDartRunConfigurationProducer.java
@@ -22,14 +22,22 @@ import com.intellij.psi.search.GlobalSearchScopesCore;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.jetbrains.lang.dart.psi.DartClassDefinition;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
+import dev.bluebiscuitdesign.cucumber.dart.CucumberDartUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.plugins.cucumber.psi.GherkinFile;
 import org.jetbrains.plugins.cucumber.psi.GherkinFileType;
+import org.jetbrains.plugins.cucumber.psi.impl.GherkinFileImpl;
 
+import java.io.BufferedReader;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.io.InputStreamReader;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 abstract public class CucumberDartRunConfigurationProducer extends LazyRunConfigurationProducer<CucumberDartRunConfiguration> {
@@ -41,9 +49,9 @@ abstract public class CucumberDartRunConfigurationProducer extends LazyRunConfig
     }
 
     @Override
-  protected boolean setupConfigurationFromContext(final @NotNull CucumberDartRunConfiguration configuration,
-                                                  final @NotNull ConfigurationContext context,
-                                                  final @NotNull Ref<PsiElement> sourceElement) {
+    protected boolean setupConfigurationFromContext(final @NotNull CucumberDartRunConfiguration configuration,
+                                                    final @NotNull ConfigurationContext context,
+                                                    final @NotNull Ref<PsiElement> sourceElement) {
         PsiFileSystemItem file = getPsiFileToRun(context);
         if (file == null) {
             return false;
@@ -181,9 +189,9 @@ abstract public class CucumberDartRunConfigurationProducer extends LazyRunConfig
     }
 
     static class RunfileConfig {
-        List<String> imports = new ArrayList<>();
-        List<String> stepClasses = new ArrayList<>();
-        List<String> instances = new ArrayList<>();
+        Set<String> imports = new HashSet<>();
+        Set<String> stepClasses = new HashSet<>();
+        Set<String> instances = new HashSet<>();
         String features;
         Project project;
     }
@@ -197,15 +205,21 @@ abstract public class CucumberDartRunConfigurationProducer extends LazyRunConfig
         final VirtualFile rootDir = pubspec == null ? null : pubspec.getParent();
         // start our config gathering, adding ogurets as the base requirement
         final RunfileConfig config = new RunfileConfig();
-        // config.imports.add("import 'package:ogurets/ogurets.dart';");
         config.project = project;
         config.features = featureFileOrDir.getPath().substring(rootDir.getPath().length() + 1);
+
+        // collect the imported packages that are known to contain step definitions used by the feature file(s)
+        PsiManager manager = PsiManager.getInstance(project);
+        Set<PsiFile> stepDefFiles = getStepDefFiles(featureFileOrDir, manager);
+        Set<VirtualFile> knownPackages = new HashSet<>();
+        urlResolver.processLivePackages((packageName, virtualFile) -> knownPackages.add(virtualFile));
+
         // we can be in a sub-folder in a project and thus this gets complicated, quickly.
         VirtualFile testDir = rootDir == null ? null : rootDir.findChild("test");
         PsiFile runFile = null;
         if (testDir != null && testDir.isDirectory() && VfsUtilCore.isAncestor(testDir, featureFileOrDir, true)) {
             // right, this file is in the $project/test folder, so lets go spelunking down to find all of the stepdefs
-            collectStepdefs(config, testDir);
+            collectStepdefs(config, testDir, stepDefFiles, knownPackages);
             // now we have to recreate the single ogurets_run.dart file
             PsiDirectory testDirectory = PsiManager.getInstance(project).findDirectory(testDir);
             runFile = createRunFile(testDirectory, OGURETS_DART_RUNNER, config, testDir);
@@ -213,15 +227,16 @@ abstract public class CucumberDartRunConfigurationProducer extends LazyRunConfig
             testDir = rootDir == null ? null : rootDir.findChild("test_driver");
             if (testDir != null && testDir.isDirectory() && VfsUtilCore.isAncestor(testDir, featureFileOrDir, true)) {
                 // this file is in the test_driver folder, do the same as above but we need to also ensure that FlutterOgurets is included
-                collectStepdefs(config, testDir);
+                collectStepdefs(config, testDir, stepDefFiles, knownPackages);
                 config.stepClasses.add("FlutterHooks"); // to ensure reset occurs
                 PsiDirectory testDirectory = PsiManager.getInstance(project).findDirectory(testDir);
                 createRunFile(testDirectory, OGURETS_FLUTTER_RUNNER, config, testDir);
                 runFile = createRunFile(testDirectory, OGURETS_FLUTTER_TEST_RUNNER, config, testDir);
                 return runFile;
-            } else if (rootDir != null) { // it isn't in 'test' or 'test_driver', so stick it in the same dir as the feature folder
+            } else if (rootDir != null) {
+                // it isn't in 'test' or 'test_driver', so stick it in the same dir as the feature folder
                 VirtualFile featureFolder = featureFileOrDir.getParent().getParent();
-                collectStepdefs(config, featureFolder);
+                collectStepdefs(config, featureFolder, stepDefFiles, knownPackages);
                 // now we have to recreate the single ogurets_run.dart file
                 PsiDirectory testDirectory = PsiManager.getInstance(project).findDirectory(featureFolder);
                 runFile = createRunFile(testDirectory, OGURETS_DART_RUNNER, config, featureFolder);
@@ -234,15 +249,131 @@ abstract public class CucumberDartRunConfigurationProducer extends LazyRunConfig
         return null;
     }
 
+    @NotNull
+    private static Set<PsiFile> getStepDefFiles(VirtualFile featureFileOrDir, PsiManager manager) {
+        Set<PsiFile> stepDefFiles = new HashSet<>();
+        if (featureFileOrDir.isDirectory()) {
+            for (VirtualFile file : featureFileOrDir.getChildren()) {
+                if (file.isDirectory()) {
+                    stepDefFiles.addAll(getStepDefFiles(file, manager));
+                } else {
+                    if (file.getName().endsWith(".feature")) {
+                        addStepDefFiles(manager, stepDefFiles, file);
+                    }
+                }
+            }
+        } else {
+            addStepDefFiles(manager, stepDefFiles, featureFileOrDir);
+        }
+        return stepDefFiles;
+    }
+
+    private static void addStepDefFiles(PsiManager manager, Set<PsiFile> stepDefFiles, VirtualFile file) {
+        FileViewProvider viewProvider = new SingleRootFileViewProvider(manager, file);
+        GherkinFile featureFile = new GherkinFileImpl(viewProvider);
+        stepDefFiles.addAll(CucumberDartUtil.getStepDefinitionContainers(featureFile));
+    }
+
     /**
-     * walk down the tree and find all of the files ready.
+     * Get the import package String for the given file.
+     * This means we'll have to look for the dart file that exports this one.
+     *
+     * @param file
+     * @return
+     */
+    private static String getImportPackage(PsiFile file, Set<VirtualFile> knownPackages) {
+        // Iteratively look for files in containing directory that might export this file
+        PsiDirectory containingDir = file.getContainingDirectory();
+        String exportFileMatch = file.getVirtualFile().getPath().substring(containingDir.getVirtualFile().getPath().length() + 1);
+        return getImportPackage(file.getContainingDirectory(), exportFileMatch, knownPackages);
+    }
+
+    /**
+     * Get the import package for a matching export filename within the given containing directory.
+     *
+     * @param containingDir
+     * @param exportFileMatch
+     * @param knownPackages
+     * @return
+     */
+    private static String getImportPackage(PsiDirectory containingDir, String exportFileMatch, Set<VirtualFile> knownPackages) {
+        for (PsiFile dirFile : containingDir.getFiles()) {
+            System.out.println(knownPackages);
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(dirFile.getVirtualFile().getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (line.startsWith("export") && line.contains(exportFileMatch)) {
+                        // Get the package that contains this file...
+                        Optional<VirtualFile> containingPackage = knownPackages.stream().filter((pkg) -> dirFile.getVirtualFile().getPath().startsWith(pkg.getPath())).findFirst();
+                        if (containingPackage.isPresent()) {
+                            // Get package name from pubspec.yaml
+                            VirtualFile pkgYaml = containingPackage.get().getParent().findChild("pubspec.yaml");
+                            String packageName = getPackageName(pkgYaml);
+                            return "package:" + packageName + "/" + dirFile.getVirtualFile().getName();
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                // Ignore ...
+            }
+        }
+        // Not yet found? Look in parent directory...
+        if (containingDir.getParent() != null) {
+            return getImportPackage(containingDir.getParent(), exportFileMatch, knownPackages);
+        }
+        return null;
+    }
+
+    private static String getPackageName(VirtualFile pkgYaml) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(pkgYaml.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith("name:")) {
+                    return line.substring(line.indexOf(":") + 1).trim();
+                }
+            }
+        } catch (IOException e) {
+            return null;
+        }
+        return null;
+    }
+
+    /**
+     * Find all files containing step definitions being used by the feature.
+     * Also look for step definitions in imported packages.
      *
      * @param config
      * @param testDir
      */
-    public static void collectStepdefs(RunfileConfig config, VirtualFile testDir) {
+    public static void collectStepdefs(RunfileConfig config,
+                                       VirtualFile testDir,
+                                       Collection<? extends PsiFile> stepDefFiles,
+                                       Set<VirtualFile> knownPackages) {
         int offsetLength = testDir.getPath().length() + 1;
+        Set<String> rawImportPaths = new HashSet<>();
+        // First look into all files that are actually used by the step definitions in the given feature.
+        stepDefFiles.forEach(file -> {
+            VirtualFile f = file.getVirtualFile();
+            // get the non-private classes
+            List<DartClassDefinition> classes =
+                    PsiTreeUtil.findChildrenOfType(file, DartClassDefinition.class).stream()
+                            .filter(c -> c.getName() != null && !c.getName().startsWith("_"))
+                            .toList();
+            if (classes.size() > 0) {
+                String importPath = f.getPath().startsWith(testDir.getPath()) ?
+                        f.getPath().substring(offsetLength) :
+                        getImportPackage(file, knownPackages);
+                // import the file with an alias
+                if (null == importPath) {
+                    return;
+                }
+                rawImportPaths.add(f.getPath());
+                addImportAndClasses(config, f, classes, importPath);
+            }
+        });
 
+        // Still, we also descend into the package's local tree structure,
+        // just to make sure we don't miss any "non-step" annotated stuff from within the package...
         VfsUtilCore.visitChildrenRecursively(testDir, new VirtualFileVisitor<VirtualFile>() {
             @Override
             public boolean visitFile(@NotNull VirtualFile f) {
@@ -250,22 +381,29 @@ abstract public class CucumberDartRunConfigurationProducer extends LazyRunConfig
                     if (f.getName().toLowerCase().endsWith(".dart")) {
                         PsiFile file = PsiManager.getInstance(config.project).findFile(f);
                         // get the non-private classes
-                        List<DartClassDefinition> classes = PsiTreeUtil.findChildrenOfType(file, DartClassDefinition.class).stream().filter(c -> c.getName() != null && !c.getName().startsWith("_")).collect(Collectors.toList());
+                        List<DartClassDefinition> classes =
+                                PsiTreeUtil.findChildrenOfType(file, DartClassDefinition.class).stream()
+                                        .filter(c -> c.getName() != null && !c.getName().startsWith("_"))
+                                        .toList();
 
-                        if (classes.size() > 0) {
+                        if (classes.size() > 0 && !rawImportPaths.contains(f.getPath())) {
                             String importPath = f.getPath().substring(offsetLength);
                             // import the file with an alias
-                            String fileAlias = toDartFileAlias(f.getName().substring(0, f.getName().length() - 5)).replaceAll("\\.", "_");
-                            // basePath already has a / at the end
-                            config.imports.add(String.format("import '%s' as %s;", importPath, fileAlias));
-
-                            classes.forEach(c -> config.stepClasses.add(String.format("%s.%s", fileAlias, c.getName())));
+                            addImportAndClasses(config, f, classes, importPath);
                         }
                     }
                 }
                 return true;
             }
         });
+    }
+
+    private static void addImportAndClasses(RunfileConfig config, VirtualFile f, List<DartClassDefinition> classes, String importPath) {
+        String fileAlias = toDartFileAlias(f.getName().substring(0, f.getName().length() - 5)).replaceAll("\\.", "_");
+        // basePath already has a / at the end
+        config.imports.add(String.format("import '%s' as %s;", importPath, fileAlias));
+
+        classes.forEach(c -> config.stepClasses.add(String.format("%s.%s", fileAlias, c.getName())));
     }
 
     // dart wants it file aliases as underscores, ref: Effective Dart
@@ -300,7 +438,7 @@ abstract public class CucumberDartRunConfigurationProducer extends LazyRunConfig
         try {
             Properties properties = new Properties();
             properties.put("IMPORTS", String.join("\n", config.imports));
-            properties.put("STEPS", config.stepClasses.stream().map(s -> String.format("  ..step(%s)\n", s)).collect(Collectors.joining()));
+            properties.put("STEPS", config.stepClasses.stream().map(s -> String.format("\n\t..step(%s)", s)).collect(Collectors.joining()));
             properties.put("FLUTTER_TEST", config.features);
             PsiFile file = FileTemplateUtil.createFromTemplate(fileTemplate, template, properties, dir).getContainingFile();
             return file;


### PR DESCRIPTION
For #16, look up and include step definition classes in the generated `ogurets_run.dart`.

Builds upon refactoring done in #17 