### PR TITLE
Also load classes that only contain Before/After hooks

### DIFF
--- a/src/main/java/dev/bluebiscuitdesign/cucumber/dart/CucumberStepIndex.java
+++ b/src/main/java/dev/bluebiscuitdesign/cucumber/dart/CucumberStepIndex.java
@@ -18,6 +18,8 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.*;
 
+import static dev.bluebiscuitdesign.cucumber.dart.steps.reference.CucumberJavaAnnotationProvider.HOOK_MARKERS;
+
 public abstract class CucumberStepIndex extends FileBasedIndexExtension<Boolean, List<Integer>> {
     private static final List<String> STEP_KEYWORDS = Arrays.asList(
             "Әмма", "Нәтиҗәдә", "Вә", "Әйтик", "Һәм", "Ләкин", "Әгәр", "Und",
@@ -136,6 +138,10 @@ public abstract class CucumberStepIndex extends FileBasedIndexExtension<Boolean,
 
     protected static boolean isStepDefinitionCall(@NotNull LighterASTNode methodName, @NotNull CharSequence text) {
         return STEP_KEYWORDS.contains(text.subSequence(methodName.getStartOffset(), methodName.getEndOffset()).toString());
+    }
+
+    protected static boolean isHookDefinitionCall(@NotNull LighterASTNode methodName, @NotNull CharSequence text) {
+        return HOOK_MARKERS.contains(text.subSequence(methodName.getStartOffset(), methodName.getEndOffset()).toString());
     }
 
     protected static boolean isStringLiteral(@NotNull LighterASTNode element, @NotNull CharSequence text) {

--- a/src/main/java/dev/bluebiscuitdesign/cucumber/dart/DartCucumberIndex.java
+++ b/src/main/java/dev/bluebiscuitdesign/cucumber/dart/DartCucumberIndex.java
@@ -36,7 +36,8 @@ public class DartCucumberIndex extends CucumberStepIndex {
                         return;
                     }
                     LighterASTNode methodNameNode = methodNameAndArgumentList.get(1);
-                    if (methodNameNode != null && isStepDefinitionCall(methodNameNode, text)) {
+                    // Include both step defs and hook methods...
+                    if (methodNameNode != null && (isStepDefinitionCall(methodNameNode, text) || isHookDefinitionCall(methodNameNode, text))) {
                         LighterASTNode expressionList = methodNameAndArgumentList.get(2);
                         if (expressionList.getTokenType() == DartTokenTypes.ARGUMENTS) {
                             LighterASTNode argumentList = LightTreeUtil.firstChildOfType(lighterAst, expressionList, DartTokenTypes.ARGUMENT_LIST);

--- a/src/main/java/dev/bluebiscuitdesign/cucumber/dart/steps/run/CucumberDartRunConfigurationProducer.java
+++ b/src/main/java/dev/bluebiscuitdesign/cucumber/dart/steps/run/CucumberDartRunConfigurationProducer.java
@@ -298,7 +298,7 @@ abstract public class CucumberDartRunConfigurationProducer extends LazyRunConfig
      */
     private static String getImportPackage(PsiDirectory containingDir, String exportFileMatch, Set<VirtualFile> knownPackages) {
         for (PsiFile dirFile : containingDir.getFiles()) {
-            System.out.println(knownPackages);
+            // System.out.println(knownPackages);
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(dirFile.getVirtualFile().getInputStream()))) {
                 String line;
                 while ((line = reader.readLine()) != null) {


### PR DESCRIPTION
When generating the `ogurets_run.dart` file, classes that only contain `Before` or `After` definitions (and no `Given`, `When` or `Then` methods) are not included. 

The idea of this PR is to also pick up and include those classes